### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-device.opam
+++ b/mirage-device.opam
@@ -19,7 +19,7 @@ doc: "https://mirage.github.io/mirage-device/"
 bug-reports: "https://github.com/mirage/mirage-device/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "fmt"
 ]
 build: [


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.