### PR TITLE
use lwt directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
  global:
    - PACKAGE="mirage-device"
  matrix:
-   - DISTRO=alpine OCAML_VERSION=4.04
-   - DISTRO=alpine OCAML_VERSION=4.05
    - DISTRO=alpine OCAML_VERSION=4.06
    - DISTRO=alpine OCAML_VERSION=4.07
+   - DISTRO=alpine OCAML_VERSION=4.08
+   - DISTRO=alpine OCAML_VERSION=4.09

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+v2.0.0
+------
+
+- specialise io to Lwt.t
+- remove type io
+
 v1.2.0 2019-02-08
 -----------------
 

--- a/mirage-device.opam
+++ b/mirage-device.opam
@@ -18,9 +18,10 @@ homepage: "https://github.com/mirage/mirage-device"
 doc: "https://mirage.github.io/mirage-device/"
 bug-reports: "https://github.com/mirage/mirage-device/issues"
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
   "fmt"
+  "lwt" {>= "4.4.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
  (name mirage_device)
  (public_name mirage-device)
- (libraries fmt))
+ (libraries fmt lwt))

--- a/src/mirage_device.ml
+++ b/src/mirage_device.ml
@@ -23,7 +23,6 @@ let pp_error ppf = function
   | `Disconnected  -> Fmt.string ppf "device is disconnected"
 
 module type S = sig
-  type +'a io
   type t
-  val disconnect: t -> unit io
+  val disconnect: t -> unit Lwt.t
 end

--- a/src/mirage_device.mli
+++ b/src/mirage_device.mli
@@ -36,13 +36,10 @@ val pp_error: error Fmt.t
     disconnect such a device. *)
 module type S = sig
 
-  type +'a io
-  (** The type for potentially blocking I/O operation *)
-
   type t
   (** The type representing the internal state of the device *)
 
-  val disconnect: t -> unit io
+  val disconnect: t -> unit Lwt.t
   (** Disconnect from the device. While this might take some time to
       complete, it can never result in an error. *)
 


### PR DESCRIPTION
see mirage/mirage#1004 for the motivation behind this PR.

Also bump minimum version to OCaml 4.06.0 (to rely on safe-string being enforced), and bump travis to include all up to 4.09.0