### PR TITLE
Revert "compatibility with older mirage"

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,4 @@
 (library
  (name mirage_device)
  (public_name mirage-device)
- (libraries fmt lwt)
- (wrapped false))
+ (libraries fmt lwt))

--- a/src/mirage_device_lwt.ml
+++ b/src/mirage_device_lwt.ml
@@ -1,3 +1,0 @@
-[@@@ocaml.deprecated "This module will be removed from MirageOS 4.0. Please use Mirage_device instead."]
-
-include Mirage_device


### PR DESCRIPTION
Reverts mirage/mirage-device#7

turns out there never was a Mirage_device_lwt, so no need to provide a transition here